### PR TITLE
Rework Options

### DIFF
--- a/iterator.go
+++ b/iterator.go
@@ -21,11 +21,11 @@ func String(input string) Iterator[rune] {
 
 func (it *stringIter) Next() Option[rune] {
 	if len(it.input) == 0 {
-		return None[rune]()
+		return NewNone[rune]()
 	}
 	value, width := utf8.DecodeRuneInString(it.input)
 	it.input = it.input[width:]
-	return Some(value)
+	return NewSome(value)
 }
 
 type rangeIter struct {
@@ -46,15 +46,15 @@ func (it *rangeIter) Next() Option[int] {
 	v := it.start + it.step*it.i
 	if it.step > 0 {
 		if v >= it.stop {
-			return None[int]()
+			return NewNone[int]()
 		}
 	} else {
 		if v <= it.stop {
-			return None[int]()
+			return NewNone[int]()
 		}
 	}
 	it.i++
-	return Some(v)
+	return NewSome(v)
 }
 
 type sliceIter[T any] struct {
@@ -70,11 +70,11 @@ func Slice[T any](slice []T) Iterator[T] {
 
 func (it *sliceIter[T]) Next() Option[T] {
 	if len(it.slice) == 0 {
-		return None[T]()
+		return NewNone[T]()
 	}
 	first := it.slice[0]
 	it.slice = it.slice[1:]
-	return Some[T](first)
+	return NewSome[T](first)
 }
 
 // ToSlice consumes an Iterator creating a slice from the yielded values.
@@ -150,7 +150,7 @@ func Take[T any](it Iterator[T], n uint) Iterator[T] {
 
 func (it *takeIter[T]) Next() Option[T] {
 	if it.take == 0 {
-		return None[T]()
+		return NewNone[T]()
 	}
 	v := it.inner.Next()
 	if v.IsSome() {
@@ -177,7 +177,7 @@ func TakeWhile[T any](it Iterator[T], pred func(T) bool) Iterator[T] {
 
 func (it *takeWhileIter[T]) Next() Option[T] {
 	if it.done {
-		return None[T]()
+		return NewNone[T]()
 	}
 	v := it.inner.Next()
 	if v.IsNone() {
@@ -186,7 +186,7 @@ func (it *takeWhileIter[T]) Next() Option[T] {
 	}
 	if !it.pred(v.Unwrap()) {
 		it.done = true
-		return None[T]()
+		return NewNone[T]()
 	}
 	return v
 }
@@ -206,7 +206,7 @@ func Drop[T any](it Iterator[T], n uint) Iterator[T] {
 }
 
 func (it *dropIter[T]) Next() Option[T] {
-	v := None[T]()
+	v := NewNone[T]()
 	for it.drop > 0 {
 		v = it.inner.Next()
 		if v.IsNone() {
@@ -263,7 +263,7 @@ func Repeat[T any](value T) Iterator[T] {
 }
 
 func (it *repeatIter[T]) Next() Option[T] {
-	return Some(it.value)
+	return NewSome(it.value)
 }
 
 // Count consumes an Iterator and returns the number of elements it yielded.
@@ -300,7 +300,7 @@ func Empty[T any]() Iterator[T] {
 }
 
 func (it *emptyIter[T]) Next() Option[T] {
-	return None[T]()
+	return NewNone[T]()
 }
 
 type onceIter[T any] struct {
@@ -310,13 +310,13 @@ type onceIter[T any] struct {
 // Once returns an Iterator that returns a value exactly once.
 func Once[T any](value T) Iterator[T] {
 	return &onceIter[T]{
-		value: Some(value),
+		value: NewSome(value),
 	}
 }
 
 func (it *onceIter[T]) Next() Option[T] {
 	v := it.value
-	it.value = None[T]()
+	it.value = NewNone[T]()
 	return v
 }
 
@@ -354,7 +354,7 @@ func Fuse[T any](it Iterator[T]) Iterator[T] {
 
 func (it *fuseIter[T]) Next() Option[T] {
 	if it.done {
-		return None[T]()
+		return NewNone[T]()
 	}
 	v := it.inner.Next()
 	if v.IsNone() {
@@ -407,7 +407,7 @@ func Flatten[T any](it Iterator[Iterator[T]]) Iterator[T] {
 func (it *flattenIter[T]) Next() Option[T] {
 	for {
 		if it.done {
-			return None[T]()
+			return NewNone[T]()
 		}
 		v := it.current.Next()
 		if v.IsSome() {
@@ -416,7 +416,7 @@ func (it *flattenIter[T]) Next() Option[T] {
 		next := it.inner.Next()
 		if next.IsNone() {
 			it.done = true
-			return None[T]()
+			return NewNone[T]()
 		}
 		it.current = next.Unwrap()
 	}

--- a/iterator_test.go
+++ b/iterator_test.go
@@ -44,11 +44,11 @@ func TestFunc(t *testing.T) {
 	v := 0
 	it := Func(func() Option[int] {
 		if v < 3 {
-			ret := Some(v)
+			ret := NewSome(v)
 			v++
 			return ret
 		} else {
-			return None[int]()
+			return NewNone[int]()
 		}
 	})
 	equals(t, it.Next().Unwrap(), 0)
@@ -129,9 +129,9 @@ func TestFuse(t *testing.T) {
 	state := true
 	it := Fuse(
 		Func(func() Option[int] {
-			ret := None[int]()
+			ret := NewNone[int]()
 			if state {
-				ret = Some(1)
+				ret = NewSome(1)
 			}
 			state = !state
 			return ret
@@ -155,7 +155,7 @@ func TestFind(t *testing.T) {
 	v := Find(it, func(i int) bool {
 		return i > 3
 	})
-	equals(t, v, Some(4))
+	equals(t, v, NewSome(4))
 }
 
 func TestFlatten(t *testing.T) {

--- a/option.go
+++ b/option.go
@@ -1,59 +1,125 @@
 package iter
 
-// Options[T] represents an optional value of type T.
-type Option[T any] struct{ value *T }
+import "errors"
 
-// Some returns an Option containing a value.
-func Some[T any](v T) Option[T] {
-	return Option[T]{value: &v}
+// SomeOrNone represents the inner value of an object
+type SomeOrNone[T any] interface {
+	Unwrappable() bool
 }
 
-// None returns an empty Option.
-func None[T any]() Option[T] {
-	return Option[T]{value: nil}
+// Some represents a value that exists. Note: we always pass Some by value,
+//because we don't want to assume how it will be used. Some also never changes,
+// so we never need a reference. This means we never force an allocation where
+// one isn't needed, and `val` can still be a pointer to avoid copying if desired.
+type Some[T any] struct{ val T }
+
+// Unwrap unwraps the value in Some
+func (s Some[T]) Unwrappable() bool {
+	return true
 }
 
-// IsNone returns true if Option is empty.
-func (opt Option[T]) IsNone() bool {
-	return opt.value == nil
+// Get returns the inner value of Some
+func (s Some[T]) Get() T {
+	return s.val
 }
 
-// IsSome returns true if Option contains a value.
-func (opt Option[T]) IsSome() bool {
-	return !opt.IsNone()
+// None represents a value that does not exist. Note: this is better than `nil` because
+// `nil` is still a value assigned to a variable of a given type. A empty struct uses no
+// memory, so really this is just a container for type data to satisfy the compiler. Whereas
+// say a slice with a `nil` value will set the zero values for it's internal fields. Using
+// nil to represent something that's un-initialized will take the minimum memory for that given
+// type, where as `None[[]int]` will take no space because `[]int` doesn't even exist in
+// memory. Even a nil pointer takes the size of a pointer still, because `nil` is still a value
+// and is just assumed to mean the zero value. This is probably a meaningless optimization, but
+// it's cool nonetheless. I mean why use memory to represent something that doesn't exist?
+type None[T any] struct{}
+
+// Unwrap returns false specifying that there is no value to unwrap
+func (n None[T]) Unwrappable() bool {
+	return false
 }
 
-// Unwrap extracts a value from Option. Panics if Option does not contain a
-// value.
-func (opt Option[T]) Unwrap() T {
-	if opt.IsNone() {
-		panic("Attempted to unwrap an empty Option.")
+var ErrUnwrapNone = errors.New("unwrapped an empty `Option`")
+
+// Option represents an actual option
+type Option[T any] interface {
+	Unwrap() T
+	UnwrapOr(v T) T
+	UnwrapOrElse(fn func() T) T
+	IsSome() bool
+	IsNone() bool
+	Get() SomeOrNone[T]
+}
+
+// the actual Option implementation
+type option[T any] struct {
+	inner SomeOrNone[T]
+}
+
+func NewSome[T any](v T) Option[T] {
+	return option[T]{inner: Some[T]{v}}
+}
+
+func NewNone[T any]() Option[T] {
+	return option[T]{inner: None[T]{}}
+}
+
+func (o option[T]) Unwrap() (t T) {
+	exists := o.inner.Unwrappable()
+	if !exists {
+		panic(ErrUnwrapNone)
 	}
-	return *opt.value
+
+	// we should know that this is should assert as Some at this point
+	t = o.inner.(Some[T]).Get()
+	return
 }
 
-// UnwrapOr extracts a value from Option or returns a default value def if the
-// Option is empty.
-func (opt Option[T]) UnwrapOr(def T) T {
-	if opt.IsSome() {
-		return opt.Unwrap()
+func (o option[T]) UnwrapOr(v T) T {
+	exists := o.inner.Unwrappable()
+	if exists {
+		// we should know that this is should assert as Some at this point
+		return o.inner.(Some[T]).Get()
 	}
-	return def
+
+	return v
 }
 
-// UnwrapOrElse extracts a value from Option or computes a value by calling fn
-// if the Option is empty.
-func (opt Option[T]) UnwrapOrElse(fn func() T) T {
-	if opt.IsSome() {
-		return opt.Unwrap()
+func (o option[T]) UnwrapOrElse(fn func() T) T {
+	exists := o.inner.Unwrappable()
+	if exists {
+		// we should know that this is should assert as Some at this point
+		return o.inner.(Some[T]).Get()
 	}
+
 	return fn()
+}
+
+func (o option[T]) IsSome() bool {
+	switch o.inner.(type) {
+	case Some[T]:
+		return true
+	default:
+		return false
+	}
+}
+func (o option[T]) IsNone() bool {
+	switch o.inner.(type) {
+	case None[T]:
+		return true
+	default:
+		return false
+	}
+}
+
+func (o option[T]) Get() SomeOrNone[T] {
+	return o.inner
 }
 
 // MapOption applies a function fn to the contained value if it exists.
 func MapOption[T any, R any](opt Option[T], fn func(T) R) Option[R] {
 	if !opt.IsSome() {
-		return None[R]()
+		return NewNone[R]()
 	}
-	return Some(fn(opt.Unwrap()))
+	return NewSome(fn(opt.Unwrap()))
 }

--- a/option_test.go
+++ b/option_test.go
@@ -1,0 +1,35 @@
+package iter
+
+import "testing"
+
+func TestOption(t *testing.T) {
+	str := "hello world"
+	var opt Option[string]
+	opt = NewSome(str)
+
+	if opt.IsNone() || !opt.IsSome() {
+		t.Fatal("option should be Some not None")
+	}
+
+	val := opt.Unwrap()
+
+	if val != str {
+		t.Fatalf("unwrap gave '%s', but '%s' was expected", val, str)
+	}
+
+	switch opt.Get().(type) {
+	case None[string]:
+		t.Fatal("option is None, should be Some")
+	}
+
+	opt = NewNone[string]()
+
+	switch opt.Get().(type) {
+	case *Some[string]:
+		t.Fatal("option is Some, should be None")
+	}
+
+	if !opt.IsNone() || opt.IsSome() {
+		t.Fatal("option should be None not Some")
+	}
+}


### PR DESCRIPTION
Hey there! I stumbled across your project because I also thought of implementing iterators in Go using generics, and I also would have taken influence from Rust. I think you've done a great job so far, however I think I have a more interesting approach to the Option type. It more closely resembles Rust, and it completely avoids the use of `nil`. I put some long descriptions in the comments, but will try to briefly reexplain here.

Your implementation takes a pointer of type `T` for the inner value. You simply compare to `nil` to tell if it's Some or None. There are 3 very very minor caveats to this:

 1. `nil` is still a value that takes memory. For example a slice of the value nil will still set zero values. A None type that is a empty struct will take no space, and basically acts as a type container for the compiler. As proof if you set a slice to a `nil` value and reflect it's structure you can see it's values get set to zero values.
 1. Taking a reference to a type makes it a candidate for allocation. This means that storing the value as a pointer of the generic type (`*T`) could in some cases make a value allocate on heap when it may not need to, and potentially requires more from the garbage collector. Ultimately what it really boils down to is letting the implementer decide what they want. The type `T` can still contain a pointer to avoid copying, and only the struct around it will be cloned.
 1. As a matter of arbitrary and useless principals I decided something that is used to avoid the pitfalls of `nil` values shouldn't use or rely on them.
 
 I could be wrong on some of this, but this is my best attempt to make the Option type behave most similarly to Rust's, and there are some potential very small and insignificant improvements with this also. Then again, I may be missing something. Regardless I think it still matches the semantics of Rust better.
 
 Let me know what you think!